### PR TITLE
Permit lack of newline, given possible piping or EOF.

### DIFF
--- a/tests/results_pipe_missing_nl_expected_stdout
+++ b/tests/results_pipe_missing_nl_expected_stdout
@@ -1,3 +1,3 @@
 1
 prompt_password_stdout2
-error
+3


### PR DESCRIPTION
Modifies the logic to no longer require a newline at the end of input. What I'm not clear on is why that was required to begin with, so please let me know if this is an unwanted change.

Before this change, `echo -n password | yourprogram` would result in an error.

Additionally, when a TTY is allocated, an error could be triggered by the user entering their password followed by `CTRL-D` twice.

Both of these scenarios are now handled by simply removing the requirement to end in a newline.