### PR TITLE
Fix Unicode input on Windows (closes #31)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -164,8 +164,8 @@ mod unix {
 mod windows {
     extern crate winapi;
     extern crate kernel32;
-    use std::io::{self, BufRead, Write};
-    use std::os::windows::io::{FromRawHandle, IntoRawHandle};
+    use std::io::{self, Write};
+    use std::os::windows::io::{FromRawHandle, AsRawHandle};
     use self::winapi::winnt::{
         GENERIC_READ, GENERIC_WRITE, FILE_SHARE_READ, FILE_SHARE_WRITE,
     };
@@ -206,11 +206,9 @@ mod windows {
         }
 
         // Read the password.
-        let mut source = io::BufReader::new(unsafe {
-            ::std::fs::File::from_raw_handle(handle)
-        });
+        let source = io::stdin();
         let input = source.read_line(&mut password);
-        let handle = source.into_inner().into_raw_handle();
+        let handle = source.as_raw_handle();
 
         // Check the response.
         match input {


### PR DESCRIPTION
Previously, only Latin characters would be preserved.

Tested on 64-bit versions of Windows 10 1809 and Windows 2012 R2 with Cyrillic and Czech characters.